### PR TITLE
Don't lose track of items when using a deposit box

### DIFF
--- a/src/main/java/com/resourcetracker/ContainerTracker.java
+++ b/src/main/java/com/resourcetracker/ContainerTracker.java
@@ -1,5 +1,7 @@
 package com.resourcetracker;
 
+import net.runelite.api.gameval.InventoryID;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,6 +48,7 @@ public class ContainerTracker
 	// Then add the config item to ResourceTrackerConfig.java
 	public static final Container BANK = new Container(95, "Bank", "trackBank");
 	public static final Container INVENTORY = new Container(93, "Inventory", "trackInventory");
+	public static final Container WORN_INVENTORY = new Container(InventoryID.WORN, "Worn Inventory", "trackInventory");
 	public static final Container SEED_VAULT = new Container(626, "Seed Vault", "trackSeedVault");
 	public static final Container RETRIEVAL_SERVICE = new Container(525, "Retrieval Service", "trackRetrievalService");
 	public static final Container GROUP_STORAGE = new Container(659, "Group storage", "trackGroupStorage");
@@ -72,6 +75,7 @@ public class ContainerTracker
 		// Register all containers
 		registerContainer(BANK);
 		registerContainer(INVENTORY);
+		registerContainer(WORN_INVENTORY);
 		registerContainer(SEED_VAULT);
 		registerContainer(RETRIEVAL_SERVICE);
 		registerContainer(GROUP_STORAGE);

--- a/src/main/java/com/resourcetracker/ResourceTrackerPlugin.java
+++ b/src/main/java/com/resourcetracker/ResourceTrackerPlugin.java
@@ -12,6 +12,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.ScriptID;
+import net.runelite.api.annotations.Interface;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
@@ -344,6 +345,12 @@ public class ResourceTrackerPlugin extends Plugin
         return containerId; // No normalization needed
     }
 
+    private boolean isInterfaceOpen(@Interface int groupId, int childId)
+    {
+        Widget w = client.getWidget(groupId, childId);
+        return w != null && !w.isHidden();
+    }
+
     public void updateTrackedItems()
     {
         // If no items are tracked, skip the update
@@ -353,6 +360,10 @@ public class ResourceTrackerPlugin extends Plugin
         }
 
         boolean needsUpdate = false;
+
+        // Will need special handling for deposit boxes
+        boolean depositBoxOpen = isInterfaceOpen(InterfaceID.BANK_DEPOSITBOX, 0) ||
+                isInterfaceOpen(InterfaceID.BANK_DEPOSIT_IMP, 0);
 
         // Only iterate through tracked items, not all container items
         for (TrackedItem trackedItem : trackedItems.values())
@@ -411,7 +422,21 @@ public class ResourceTrackerPlugin extends Plugin
                 }
             }
 
-            if (hasScannedData && (trackedItem.getCurrentAmount() != totalAmount || !breakdown.equals(savedBreakdown)))
+            int savedAmount = trackedItem.getCurrentAmount();
+            int diff = savedAmount - totalAmount;
+
+            // if quantity changed with deposit box interface open, assume items went to the bank.
+            // allow negative diffs to account for equipping/unequipping trackable items such as ammo.
+            if (!isRestrictedToInventory && depositBoxOpen && diff != 0)
+            {
+                final String bankKey = ContainerTracker.BANK.getName();
+                Integer bankQty = breakdown.get(bankKey);
+                bankQty = (bankQty == null ? 0 : bankQty) + diff;
+                breakdown.put(bankKey, bankQty);
+                totalAmount += diff;
+            }
+
+            if (hasScannedData && (savedAmount != totalAmount || !breakdown.equals(savedBreakdown)))
             {
                 trackedItem.setCurrentAmount(totalAmount);
                 trackedItem.setContainerQuantities(breakdown);


### PR DESCRIPTION
This change checks for inventory changes when the deposit box interface is open and assumes that items disappearing means there was a deposit. Currently, items deposited via the deposit box are assumed to be lost. This change still does not account for the case of using an item on the deposit box object. To account for equipping and unequipping tracked items, I also added the worn inventory to the tracked containers.

The only scenario I've thought of where this would break tracking is if a tracked item appeared in the inventory while using the deposit box, like a gnomeball or snowball. I'm not sure if it's even possible to receive them with an interface open, but that seems obscure enough not to matter, and the numbers would correct themselves once the real bank interface was opened.